### PR TITLE
fix: home routing when logged in

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -35,7 +35,7 @@ export const Header: React.FC = () => {
 
   return (
     <div className={styles.header}>
-      <Link href="/" passHref={true}>
+      <Link href={user ? '/projects' : '/'} passHref={true}>
         <div className={styles.icon}>{logo}</div>
       </Link>
       <div className={styles.links}>


### PR DESCRIPTION
logo/home button in the header routes to the projects page when user is logged in